### PR TITLE
fix: arm64 architecture detection

### DIFF
--- a/deployment/src/main/java/io/kiota/quarkus/deployment/KiotaCodeGen.java
+++ b/deployment/src/main/java/io/kiota/quarkus/deployment/KiotaCodeGen.java
@@ -332,7 +332,7 @@ public abstract class KiotaCodeGen implements CodeGenProvider {
             String architecture = osArch;
             if (architecture.equals("x86_64")) {
                 architecture = "x64";
-            } else if (architecture.equals("aarch64")) {
+            } else if (architecture.equals("aarch_64")) {
                 architecture = "arm64";
             } else {
                 throw new CodeGenException(


### PR DESCRIPTION
The return value of `io.quarkus.utilities.OS.getArchitecture` for ARM64 devices is `aarch_64` and not `aarch64`.

Fixes #153